### PR TITLE
Use `class:boolean` directive

### DIFF
--- a/src/components/RentalImage.svelte
+++ b/src/components/RentalImage.svelte
@@ -2,14 +2,14 @@
   export let src;
   export let alt;
 
-  let isLarge = false;
+  let large = false;
 
   function toggleSize() {
-		isLarge = !isLarge;
-	}
+    large = !large;
+  }
 </script>
 
-<button type="button" class="image {isLarge ? "large" : ""}" on:click={toggleSize}>
+<button type="button" class="image" class:large on:click={toggleSize}>
   <img src={src} alt={alt}>
-  <small>View {isLarge ? "Smaller" : "Larger"}</small>
+  <small>View {large ? "Smaller" : "Larger"}</small>
 </button>


### PR DESCRIPTION
If you want to keep the variable to be named `isLarge` but the class name to be `large`, you can do
```html
<button type="button" class="image" class:large={isLarge} on:click={toggleSize}>
```

The main advantage is to avoid the silly ternary operator with an empty string as second argument and you don't care about trailing spaced in classes