### PR TITLE
Add alternate route name for Contact page

### DIFF
--- a/src/routes/getting-in-touch.svelte
+++ b/src/routes/getting-in-touch.svelte
@@ -1,5 +1,5 @@
 <script>
-  import Contact from './Contact.svelte';
+  import Contact from './contact.svelte';
 </script>
 
 <Contact />

--- a/src/routes/getting-in-touch.svelte
+++ b/src/routes/getting-in-touch.svelte
@@ -1,0 +1,5 @@
+<script>
+  import Contact from './Contact.svelte';
+</script>
+
+<Contact />


### PR DESCRIPTION
- Add route for `getting-in-touch` that renders Contact route

Since Svelte has a file-based routing system, it doesn't have a router itself like Ember does to map routes.  Adding a static route that renders another route within it seems to be the best option if you have to go this route.  There might be other solutions out there, but this seemed the easiest way to go about it.

![Screen Shot 2021-07-16 at 11 56 49 AM](https://user-images.githubusercontent.com/1759897/125975578-3729e7c7-b3c0-46f9-9e30-148d4a15e7fe.png)


Closes #4 